### PR TITLE
GeofenceのAPIの実装の途中

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -7,7 +7,7 @@
       </SelectionState>
       <SelectionState runConfigName="MainActivity">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-10-27T03:56:22.437633100Z">
+        <DropdownSelection timestamp="2024-11-05T11:58:21.528926Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=41311FDJH000G6" />

--- a/app/src/main/java/com/example/fitbattleandroid/activity/PermissionsRationaleActivity.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/activity/PermissionsRationaleActivity.kt
@@ -4,8 +4,11 @@ import android.os.Bundle
 import android.os.PersistableBundle
 import androidx.activity.ComponentActivity
 
-class PermissionsRationaleActivity: ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
+class PermissionsRationaleActivity : ComponentActivity() {
+    override fun onCreate(
+        savedInstanceState: Bundle?,
+        persistentState: PersistableBundle?,
+    ) {
         super.onCreate(savedInstanceState, persistentState)
     }
 }

--- a/app/src/main/java/com/example/fitbattleandroid/data/EncounterRemoteDatasource.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/data/EncounterRemoteDatasource.kt
@@ -1,6 +1,5 @@
 package com.example.fitbattleandroid.data
 
-import android.util.Log
 import com.example.fitbattleandroid.data.remote.EntryGeoFenceReq
 import com.example.fitbattleandroid.data.remote.EntryGeoFenceRes
 import io.ktor.client.HttpClient
@@ -33,7 +32,6 @@ class EncounterRemoteDatasource {
         entry: EntryGeoFenceReq,
         userToken: String,
     ): EntryGeoFenceRes {
-        Log.d("entry", userToken + "受け取っているトークン")
         val res =
             client.post("http://192.168.11.3:7070/api/v1/location/geofence/entry") {
                 headers {
@@ -42,7 +40,6 @@ class EncounterRemoteDatasource {
                 contentType(ContentType.Application.Json)
                 setBody(entry)
             }
-        Log.d("result", res.toString())
         // レスポンスからボディを取得して変数に追加
         val responseBody = res.body<EntryGeoFenceRes>()
         return responseBody

--- a/app/src/main/java/com/example/fitbattleandroid/data/EncounterRemoteDatasource.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/data/EncounterRemoteDatasource.kt
@@ -1,5 +1,6 @@
 package com.example.fitbattleandroid.data
 
+import android.util.Log
 import com.example.fitbattleandroid.data.remote.EntryGeoFenceReq
 import com.example.fitbattleandroid.data.remote.EntryGeoFenceRes
 import io.ktor.client.HttpClient
@@ -8,7 +9,9 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
+import io.ktor.http.headers
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
@@ -26,16 +29,20 @@ class EncounterRemoteDatasource {
         }
 
     // ジオフェンス入室リクエスト関数
-    suspend fun sendGeoFenceEntryRequest(entry: EntryGeoFenceReq): EntryGeoFenceRes {
+    suspend fun sendGeoFenceEntryRequest(
+        entry: EntryGeoFenceReq,
+        userToken: String,
+    ): EntryGeoFenceRes {
+        Log.d("entry", userToken + "受け取っているトークン")
         val res =
-            client.post("http://192.168.224.234:7070/api/v1/geofence/entry") {
+            client.post("http://192.168.11.3:7070/api/v1/location/geofence/entry") {
+                headers {
+                    append(HttpHeaders.Authorization, "Bearer $userToken")
+                }
                 contentType(ContentType.Application.Json)
                 setBody(entry)
-//                // TODO login/新規登録時のトークンをtokenに代入
-//                headers {
-//                    append("Authorization", "Bearer ${token}")
-//                }
             }
+        Log.d("result", res.toString())
         // レスポンスからボディを取得して変数に追加
         val responseBody = res.body<EntryGeoFenceRes>()
         return responseBody

--- a/app/src/main/java/com/example/fitbattleandroid/data/EncounterRemoteDatasource.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/data/EncounterRemoteDatasource.kt
@@ -6,12 +6,12 @@ import com.example.fitbattleandroid.data.remote.EntryGeoFenceRes
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
-import io.ktor.http.headers
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 

--- a/app/src/main/java/com/example/fitbattleandroid/repository/GeofenceEntryRepository.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/repository/GeofenceEntryRepository.kt
@@ -4,5 +4,8 @@ import com.example.fitbattleandroid.data.remote.EntryGeoFenceReq
 import com.example.fitbattleandroid.data.remote.EntryGeoFenceRes
 
 interface GeofenceEntryRepository {
-    suspend fun sendGeofenceEntryRequest(entryGeofenceReq: EntryGeoFenceReq): EntryGeoFenceRes
+    suspend fun sendGeofenceEntryRequest(
+        entryGeofenceReq: EntryGeoFenceReq,
+        userToken: String,
+    ): EntryGeoFenceRes
 }

--- a/app/src/main/java/com/example/fitbattleandroid/repositoryImpl/GeofenceEntryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/repositoryImpl/GeofenceEntryRepositoryImpl.kt
@@ -8,6 +8,8 @@ import com.example.fitbattleandroid.repository.GeofenceEntryRepository
 class GeofenceEntryRepositoryImpl(
     private val remoteDatasource: EncounterRemoteDatasource,
 ) : GeofenceEntryRepository {
-    override suspend fun sendGeofenceEntryRequest(entryGeofenceReq: EntryGeoFenceReq): EntryGeoFenceRes =
-        remoteDatasource.sendGeoFenceEntryRequest(entryGeofenceReq)
+    override suspend fun sendGeofenceEntryRequest(
+        entryGeofenceReq: EntryGeoFenceReq,
+        userToken: String,
+    ): EntryGeoFenceRes = remoteDatasource.sendGeoFenceEntryRequest(entryGeofenceReq, userToken)
 }

--- a/app/src/main/java/com/example/fitbattleandroid/ui/navigation/NavHost.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/ui/navigation/NavHost.kt
@@ -29,6 +29,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.example.fitbattleandroid.MyApplication
 import com.example.fitbattleandroid.data.EncounterRemoteDatasource
 import com.example.fitbattleandroid.data.FitnessRemoteDataSource
 import com.example.fitbattleandroid.repositoryImpl.AuthRepositoryImpl
@@ -41,8 +42,8 @@ import com.example.fitbattleandroid.ui.screen.MapScreen
 import com.example.fitbattleandroid.ui.screen.RegistrationScreen
 import com.example.fitbattleandroid.ui.theme.primaryContainerDarkMediumContrast
 import com.example.fitbattleandroid.viewmodel.AuthViewModel
+import com.example.fitbattleandroid.viewmodel.GeofenceMapViewModel
 import com.example.fitbattleandroid.viewmodel.HealthConnectViewModel
-import com.example.fitbattleandroid.viewmodel.HealthDataApiViewModel
 import com.example.fitbattleandroid.viewmodel.MapViewModel
 import com.websarva.wings.android.myapplication.TopScreen
 
@@ -104,9 +105,12 @@ fun App(
             MainNavigation(
                 requestPermissionLauncher,
                 mapViewModel,
-                dataAPIViewModel =
+                geofenceMapViewModel =
                     viewModel {
-                        HealthDataApiViewModel(GeofenceEntryRepositoryImpl(EncounterRemoteDatasource()))
+                        GeofenceMapViewModel(
+                            application = context as MyApplication,
+                            GeofenceEntryRepositoryImpl(EncounterRemoteDatasource())
+                        )
                     },
                 backgroundPermissionGranted,
                 healthConnectClient,
@@ -120,7 +124,7 @@ fun App(
 fun MainNavigation(
     requestPermissionLauncher: ActivityResultLauncher<Array<String>>,
     mapViewModel: MapViewModel,
-    dataAPIViewModel: HealthDataApiViewModel,
+    geofenceMapViewModel: GeofenceMapViewModel,
     backgroundPermissionGranted: MutableState<Boolean>,
     healthConnectClient: HealthConnectClient,
 ) {
@@ -185,7 +189,7 @@ fun MainNavigation(
                     requestPermissionLauncher,
                     mapViewModel,
                     backgroundPermissionGranted,
-                    healthDataApiViewModel = dataAPIViewModel,
+                    geofenceMapViewModel = geofenceMapViewModel,
                 )
             }
             composable(Screen.MyData.route) {
@@ -201,7 +205,7 @@ fun MainNavigation(
                 )
             }
             composable(Screen.EncounterList.route) {
-                val geofenceEntryState = dataAPIViewModel.geofenceEntryState.collectAsState().value
+                val geofenceEntryState = geofenceMapViewModel.geofenceEntryState.collectAsState().value
 
                 EncounterHistoryScreen(
                     modifier = Modifier,

--- a/app/src/main/java/com/example/fitbattleandroid/ui/navigation/NavHost.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/ui/navigation/NavHost.kt
@@ -109,7 +109,7 @@ fun App(
                     viewModel {
                         GeofenceMapViewModel(
                             application = context as MyApplication,
-                            GeofenceEntryRepositoryImpl(EncounterRemoteDatasource())
+                            GeofenceEntryRepositoryImpl(EncounterRemoteDatasource()),
                         )
                     },
                 backgroundPermissionGranted,

--- a/app/src/main/java/com/example/fitbattleandroid/ui/screen/LoginScreen.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/ui/screen/LoginScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.example.fitbattleandroid.MyApplication
 import com.example.fitbattleandroid.repositoryImpl.AuthRepositoryImpl
 import com.example.fitbattleandroid.ui.common.Background
 import com.example.fitbattleandroid.ui.common.Body
@@ -34,6 +35,7 @@ fun LoginScreen(
 ) {
     val loginState = authViewModel.loginState
     val context = LocalContext.current
+    val applicationContext = context.applicationContext as MyApplication
     val scope = rememberCoroutineScope()
 
     Background {
@@ -66,11 +68,13 @@ fun LoginScreen(
                             when (authResult) {
                                 is AuthState.Loading -> {}
                                 is AuthState.Success -> {
-                                    authViewModel.saveAuthToken(
-                                        context,
-                                        authResult.token,
-                                    )
-                                    navController.navigate("main")
+                                    scope.launch {
+                                        authViewModel.saveAuthToken(
+                                            applicationContext,
+                                            authResult.token,
+                                        )
+                                        navController.navigate("main")
+                                    }
                                 }
                                 is AuthState.Error -> {}
                                 else -> {}

--- a/app/src/main/java/com/example/fitbattleandroid/ui/screen/MapScreen.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/ui/screen/MapScreen.kt
@@ -35,7 +35,7 @@ import com.example.fitbattleandroid.model.LocationData
 import com.example.fitbattleandroid.ui.permissioncheck.LocationPermissionRequest
 import com.example.fitbattleandroid.ui.theme.onPrimaryDark
 import com.example.fitbattleandroid.ui.theme.primaryContainerDarkMediumContrast
-import com.example.fitbattleandroid.viewmodel.HealthDataApiViewModel
+import com.example.fitbattleandroid.viewmodel.GeofenceMapViewModel
 import com.example.fitbattleandroid.viewmodel.MapViewModel
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.maps.model.CameraPosition
@@ -56,7 +56,7 @@ fun MapScreen(
     requestPermissionLauncher: ActivityResultLauncher<Array<String>>,
     mapViewModel: MapViewModel,
     backgroundPermissionGranted: MutableState<Boolean>,
-    healthDataApiViewModel: HealthDataApiViewModel,
+    geofenceMapViewModel: GeofenceMapViewModel,
 ) {
     val locationData = mapViewModel.location.collectAsState().value
     val geofenceList = mapViewModel.geofenceList
@@ -120,8 +120,7 @@ fun MapScreen(
                     mapViewModel.addGeofence()
                     mapViewModel.registerGeofence()
                     scope.launch(Dispatchers.IO) {
-                        val response =
-                            healthDataApiViewModel.sendGeoFenceEntryRequest(
+                            geofenceMapViewModel.sendGeoFenceEntryRequest(
                                 EntryGeoFenceReq(
                                     userId = 12,
                                     geoFenceId = 2,

--- a/app/src/main/java/com/example/fitbattleandroid/ui/screen/MapScreen.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/ui/screen/MapScreen.kt
@@ -120,13 +120,13 @@ fun MapScreen(
                     mapViewModel.addGeofence()
                     mapViewModel.registerGeofence()
                     scope.launch(Dispatchers.IO) {
-                            geofenceMapViewModel.sendGeoFenceEntryRequest(
-                                EntryGeoFenceReq(
-                                    userId = 12,
-                                    geoFenceId = 2,
-                                    entryTime = "2021-10-01T10:00:00.391Z",
-                                ),
-                            )
+                        geofenceMapViewModel.sendGeoFenceEntryRequest(
+                            EntryGeoFenceReq(
+                                userId = 12,
+                                geoFenceId = 2,
+                                entryTime = "2021-10-01T10:00:00.391Z",
+                            ),
+                        )
                     }
                 }
             },

--- a/app/src/main/java/com/example/fitbattleandroid/ui/screen/RegistrationScreen.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/ui/screen/RegistrationScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.example.fitbattleandroid.MyApplication
 import com.example.fitbattleandroid.repositoryImpl.AuthRepositoryImpl
 import com.example.fitbattleandroid.ui.common.Background
 import com.example.fitbattleandroid.ui.common.Body
@@ -35,6 +36,7 @@ fun RegistrationScreen(
 ) {
     val registerState = authViewModel.registerState
     val context = LocalContext.current
+    val applicationContext = context.applicationContext as MyApplication
     val scope = rememberCoroutineScope()
 
     Background {
@@ -77,11 +79,13 @@ fun RegistrationScreen(
                                 )
                             when (authResult) {
                                 is AuthState.Success -> {
-                                    navController.navigate("main")
-                                    authViewModel.saveAuthToken(
-                                        context,
-                                        authResult.token,
-                                    )
+                                    scope.launch {
+                                        authViewModel.saveAuthToken(
+                                            applicationContext,
+                                            authResult.token,
+                                        )
+                                        navController.navigate("main")
+                                    }
                                 }
                                 else -> {}
                             }

--- a/app/src/main/java/com/example/fitbattleandroid/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/viewmodel/AuthViewModel.kt
@@ -91,13 +91,11 @@ class AuthViewModel(
     }
 
     // トークンの保存
-    fun saveAuthToken(
+    suspend fun saveAuthToken(
         context: Context,
         token: String,
     ) {
-        viewModelScope.launch {
-            DataStoreManager.saveAuthToken(context, token)
-        }
+        DataStoreManager.saveAuthToken(context, token)
         getAuthToken(context)
     }
 
@@ -107,6 +105,7 @@ class AuthViewModel(
         viewModelScope.launch {
             DataStoreManager.getAuthToken(context).collect { token ->
                 (getApplication() as MyApplication).userToken = token
+                Log.d("result", (getApplication() as MyApplication).userToken.toString() + "aaa")
             }
         }
     }

--- a/app/src/main/java/com/example/fitbattleandroid/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/viewmodel/AuthViewModel.kt
@@ -105,7 +105,6 @@ class AuthViewModel(
         viewModelScope.launch {
             DataStoreManager.getAuthToken(context).collect { token ->
                 (getApplication() as MyApplication).userToken = token
-                Log.d("result", (getApplication() as MyApplication).userToken.toString() + "aaa")
             }
         }
     }

--- a/app/src/main/java/com/example/fitbattleandroid/viewmodel/GeofenceMapViewModel.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/viewmodel/GeofenceMapViewModel.kt
@@ -1,6 +1,8 @@
 package com.example.fitbattleandroid.viewmodel
 
-import androidx.lifecycle.ViewModel
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import com.example.fitbattleandroid.MyApplication
 import com.example.fitbattleandroid.data.remote.EntryGeoFenceReq
 import com.example.fitbattleandroid.data.remote.EntryGeoFenceRes
 import com.example.fitbattleandroid.repositoryImpl.GeofenceEntryRepositoryImpl
@@ -15,12 +17,20 @@ class GeofenceMapViewModel(
     private val _geofenceEntryState = MutableStateFlow<GeofenceEntryState>(GeofenceEntryState.Loading)
     val geofenceEntryState: StateFlow<GeofenceEntryState> = _geofenceEntryState.asStateFlow()
 
+    private val userToken = (getApplication() as MyApplication).userToken
+
     // ジオフェンス入室リクエスト関数
     suspend fun sendGeoFenceEntryRequest(entry: EntryGeoFenceReq) {
         try {
-            val res = repository.sendGeofenceEntryRequest(entry)
-            _geofenceEntryState.value = GeofenceEntryState.Success(res)
+            if (userToken == null) {
+                _geofenceEntryState.value = GeofenceEntryState.Error
+                return
+            } else {
+                val res = repository.sendGeofenceEntryRequest(entry, userToken)
+                _geofenceEntryState.value = GeofenceEntryState.Success(res)
+            }
         } catch (e: Exception) {
+            Log.d("result", e.toString())
             _geofenceEntryState.value = GeofenceEntryState.Error
         }
     }

--- a/app/src/main/java/com/example/fitbattleandroid/viewmodel/GeofenceMapViewModel.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/viewmodel/GeofenceMapViewModel.kt
@@ -8,9 +8,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class HealthDataApiViewModel(
+class GeofenceMapViewModel(
+    application: MyApplication,
     private val repository: GeofenceEntryRepositoryImpl,
-) : ViewModel() {
+) : AndroidViewModel(application) {
     private val _geofenceEntryState = MutableStateFlow<GeofenceEntryState>(GeofenceEntryState.Loading)
     val geofenceEntryState: StateFlow<GeofenceEntryState> = _geofenceEntryState.asStateFlow()
 


### PR DESCRIPTION
# やったこと
- [x] ViewModelを適切な名前に変更
- [x] ユーザートークンをDataStoreに保存
- [x] トークンを使ったジオフェンスのエントリAPIの実装

# やってないこと
- トークンが存在する際に新規登録・ログイン画面をスキップすること


# 問題点（解決済み）

- [x] EncounterRemoteDatasource.kt内のsendGeoFenceEntryRequestのヘッダーに渡すトークンでサーバー間での認証エラーが発生中