### PR TITLE
位置情報を許可してすぐに画面がReComposeされ、現在地が表示されるように修正

### DIFF
--- a/app/src/main/java/com/example/fitbattleandroid/ui/screen/MapScreen.kt
+++ b/app/src/main/java/com/example/fitbattleandroid/ui/screen/MapScreen.kt
@@ -82,11 +82,21 @@ fun MapScreen(
                     when {
                         permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) -> {
                             Log.d(TAG, "正確な位置情報の権限が許可されました")
+                            accessFineLocationState.value =
+                                ContextCompat.checkSelfPermission(
+                                    context,
+                                    Manifest.permission.ACCESS_FINE_LOCATION,
+                                ) == PackageManager.PERMISSION_GRANTED
                             showRequestBackgroundPermissionDialog.value = true
                         }
 
                         permissions.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false) -> {
                             Log.d(TAG, "おおよその位置情報の権限が許可されました")
+                            accessCoarseLocationState.value =
+                                ContextCompat.checkSelfPermission(
+                                    context,
+                                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                                ) == PackageManager.PERMISSION_GRANTED
                             showUpgradeToPreciseLocationDialog.value = true
                         }
 


### PR DESCRIPTION
# やったこと

- [x] アプリの初めに位置情報の権限を付与されてすぐ、権限の状態を更新し、現在地を表示した